### PR TITLE
Add Magentic orchestration and new Cuisine agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ This dynamic feedback loop enhances student understanding while minimizing manua
 
 ## 🔗 Core Components
 
-### 🧠 3 Specialized Agents
+### 🧠 4 Specialized Agents
 
 - **Quiz Generator Agent (GPT-4.1):** Extracts key concepts and formulates relevant questions from the uploaded course.
 - **Performance Analyzer Agent (GPT-4.1):** Evaluates quiz results to identify misunderstood concepts and skill gaps.
 - **Remediation Agent (GPT-4.1):** Builds custom learning modules and explanations to reinforce weak areas.
+- **Cuisine Agent (GPT-4.1):** Provides cooking tips and simple recipes on request.
 
 ### 🤖 Agent Manager
 
-- Orchestrated by **Semantic Kernel**, it coordinates agent interactions, manages context, and ensures learning continuity.
+- Powered by **Magentic** and **Semantic Kernel**, it coordinates agent interactions, manages context, and ensures learning continuity.
 
 ---
 

--- a/Server/API/API.csproj
+++ b/Server/API/API.csproj
@@ -16,8 +16,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.47.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.55.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Magentic" Version="1.55.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.55.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 

--- a/Server/API/Program.cs
+++ b/Server/API/Program.cs
@@ -5,6 +5,7 @@ using Infrastructure.Ai;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.Agents.Magentic;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -82,14 +83,14 @@ builder.Services.AddCors(options =>
 });
 
 // ---------------------------------------------------------------------------
-// 4. AgentGroupChat (orchestration multi-agents)
+// 4. MagenticOrchestration (multi-agents)
 // ---------------------------------------------------------------------------
 #pragma warning disable SKEXP0110
-builder.Services.AddSingleton<AgentGroupChat>(sp =>
+builder.Services.AddSingleton<MagenticOrchestration>(sp =>
 #pragma warning restore SKEXP0110
 {
     var kernel = sp.GetRequiredService<Kernel>();
-    return AgentOrchestration.Build(kernel);       // crée IssueDetector, IssueTutor, Coach
+    return AgentOrchestration.Build(kernel);       // crée IssueDetector, IssueTutor, Coach, Cuisine
 });
 
 // ---------------------------------------------------------------------------

--- a/Server/Application/Application.csproj
+++ b/Server/Application/Application.csproj
@@ -4,7 +4,8 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.55.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Magentic" Version="1.55.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Server/Application/Services/RemediationLoopService.cs
+++ b/Server/Application/Services/RemediationLoopService.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using Application.Dtos;
 using Microsoft.SemanticKernel.Agents.Chat;
+using Microsoft.SemanticKernel.Agents.Magentic;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
@@ -13,14 +14,14 @@ namespace Application.Services;
 public sealed class RemediationLoopService
 {
 #pragma warning disable SKEXP0110
-    private readonly AgentGroupChat _chat;
+    private readonly MagenticOrchestration _chat;
 #pragma warning restore SKEXP0110
     private readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
     private readonly IQuizRepository _quizzes;
     private readonly ILogger<RemediationLoopService> _logger;
 
 #pragma warning disable SKEXP0110
-    public RemediationLoopService(AgentGroupChat chat, IQuizRepository quizzes,
+    public RemediationLoopService(MagenticOrchestration chat, IQuizRepository quizzes,
         ILogger<RemediationLoopService> logger)
 #pragma warning restore SKEXP0110
     {

--- a/Server/Domain/Domain.csproj
+++ b/Server/Domain/Domain.csproj
@@ -12,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.55.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Magentic" Version="1.55.0-preview" />
   </ItemGroup>
 
 </Project>

--- a/Server/Infrastructure/Ai/AgentOrchestration.cs
+++ b/Server/Infrastructure/Ai/AgentOrchestration.cs
@@ -1,39 +1,26 @@
-﻿using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.Agents.Chat;
-#pragma warning disable SKEXP0110
+using Microsoft.SemanticKernel.Agents.Magentic;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.PromptExecution;
 
 namespace Infrastructure.Ai;
 
 public static class AgentOrchestration
 {
-    public static AgentGroupChat Build(Kernel kernel)
+    public static MagenticOrchestration Build(Kernel kernel)
     {
-        // 1) Agents
         var detector = IssueDetectorAgent.Create(kernel);
-        var tutor = IssueTutorAgent.CreateIssueTutor(kernel);
-        var coach = CoachAgent.Create(kernel);
+        var tutor    = IssueTutorAgent.CreateIssueTutor(kernel);
+        var coach    = CoachAgent.Create(kernel);
+        var cuisine  = CuisineAgent.Create(kernel);
 
-        // 2) Stratégies
-        var selection = new SequentialSelectionStrategy();
+        var service  = kernel.GetRequiredService<IChatCompletionService>();
+        var settings = new PromptExecutionSettings();
+        var manager  = new StandardMagenticManager(service, settings);
 
-        var stopFn = kernel.CreateFunctionFromPrompt("return $input == \"stop\"");
-        var termination = new KernelFunctionTerminationStrategy(stopFn, kernel)
-        {
-            Agents = new[] { coach }, 
-            MaximumIterations = 8            // borne de sécurité
-        };
-
-        // 3) GroupChat + settings (init-only → objet imbriqué)
-        var chat = new AgentGroupChat(detector, tutor, coach)
-        {
-            ExecutionSettings = new AgentGroupChatSettings
-            {
-                SelectionStrategy   = selection,
-                TerminationStrategy = termination
-            }
-        };
-
+        var chat = new MagenticOrchestration(manager, new Agent[] { detector, tutor, coach, cuisine });
         return chat;
     }
 }

--- a/Server/Infrastructure/Ai/CuisineAgent.cs
+++ b/Server/Infrastructure/Ai/CuisineAgent.cs
@@ -1,0 +1,18 @@
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+
+namespace Infrastructure.Ai;
+
+public static class CuisineAgent
+{
+    public static ChatCompletionAgent Create(Kernel kernel) => new()
+    {
+        Name = "Cuisine",
+        Kernel = kernel,
+        Instructions = """
+You are a culinary expert.
+Provide concise cooking tips, recipes, and food recommendations.
+Keep answers short (maximum 100 words) and friendly.
+"""
+    };
+}

--- a/Server/Infrastructure/Infrastructure.csproj
+++ b/Server/Infrastructure/Infrastructure.csproj
@@ -15,8 +15,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.47.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.55.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Magentic" Version="1.55.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.55.0" />
     <PackageReference Include="PdfPig" Version="0.1.10" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- switch agent manager to `MagenticOrchestration`
- include new cooking focused agent
- bump Semantic Kernel packages and add Magentic package
- document the new agent and manager

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843854ea170832a816501ba32635ea4